### PR TITLE
update default virtuoso version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     volumes:
       - ./config/dispatcher:/config
   db:
-    image: tenforce/virtuoso:1.0.0-virtuoso7.2.4
+    image: tenforce/virtuoso:1.3.0-virtuoso7.2.2
     environment:
       SPARQL_UPDATE: "true"
       DEFAULT_GRAPH: "http://mu.semte.ch/application"


### PR DESCRIPTION
current docker-compose.yml file uses a docker virtuoso image that is 2 years old, I've changed the version to the latest available. 
Also preferring virtuoso7.2.2 over virtuoso7.2.4 due to some nasty bugs that are present in 7.2.4