### PR TITLE
Fix typo

### DIFF
--- a/config/resources/repository.lisp
+++ b/config/resources/repository.lisp
@@ -25,7 +25,7 @@
 
 
 ;;;;;
-;; You can use the muext: prefix when you're still searching for
+;; You can use the ext: prefix when you're still searching for
 ;; the right predicates during development.  This should *not* be
 ;; used to publish any data under.  It's merely a prefix of which
 ;; the mu.semte.ch organisation indicates that it will not be used


### PR DESCRIPTION
Make the comments suggest the right prefix

Was a little confusing when I used it for the first time, thought there was some implicit magic that would prepend `mu` to the prefix
name or something