### PR TITLE
rename db to database

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - resource:resource
     volumes:
       - ./config/dispatcher:/config
-  db:
+  database:
     image: tenforce/virtuoso:1.3.2-virtuoso7.2.2
     environment:
       SPARQL_UPDATE: "true"
@@ -26,6 +26,6 @@ services:
   resource:
     image: semtech/mu-cl-resources:1.20.0
     links:
-      - db:database
+      - database:database
     volumes:
       - ./config/resources:/config


### PR DESCRIPTION
rename db to database, this is more consistent and also allows users to remove the `links` mapping for most services if they so chose.