### PR TITLE
Correct dispatcher function name define_layers

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -9,7 +9,7 @@ defmodule Dispatcher do
   @json %{ accept: %{ json: true } }
   @html %{ accept: %{ html: true } }
 
-  layers [ :static, :services, :fall_back, :not_found ]
+  define_layers [ :static, :services, :fall_back, :not_found ]
 
   # In order to forward the 'themes' resource to the
   # resource service, use the following forward rule:


### PR DESCRIPTION
Prevents error:

    dispatcher_1  | == Compilation error in file lib/dispatcher.ex ==
    dispatcher_1  | ** (CompileError) lib/dispatcher.ex:12: undefined function layers/1